### PR TITLE
Make it possible to configure CreateTimeSeries timeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ import gauge from "./lib/gauge.js";
 import summary from "./lib/summary.js";
 import cloudRunResourceProvider from "./lib/cloudRunResourceProvider.js";
 
-function pushClient({ intervalSeconds, createTimeSeriesTimeoutSeconds, logger, resourceProvider } = {}) {
+function pushClient({ intervalSeconds, createTimeSeriesTimeoutSeconds = 40, logger, resourceProvider } = {}) {
   if (intervalSeconds < 1) {
     throw new Error("intervalSeconds must be at least 1");
   }

--- a/test/options-specs.js
+++ b/test/options-specs.js
@@ -15,7 +15,7 @@ describe("options", () => {
     sandbox.restore();
   });
   describe("without createTimeSeriesTimeoutSeconds", () => {
-    it("is not passed to MetricServiceClient", () => {
+    it("a default is passed to MetricServiceClient", () => {
       let ctorOpts;
       class FakeMetricServiceClient {
         constructor(opts) {
@@ -27,7 +27,19 @@ describe("options", () => {
         projectId: "myproject",
         resourceProvider: globalResourceProvider,
       });
-      expect(ctorOpts).to.eql({});
+      expect(ctorOpts).to.eql({
+        clientConfig: {
+          interfaces: {
+            "google.monitoring.v3.MetricService": {
+              methods: {
+                CreateTimeSeries: {
+                  timeout_millis: 40000,
+                },
+              },
+            },
+          },
+        },
+      });
     });
   });
   describe("with createTimeSeriesTimeoutSeconds", () => {

--- a/test/options-specs.js
+++ b/test/options-specs.js
@@ -1,0 +1,64 @@
+import { expect } from "chai";
+import { pushClient } from "../index.js";
+import globalResourceProvider from "./helpers/globalResourceProvider.js";
+import monitoring from "@google-cloud/monitoring";
+import sinon from "sinon";
+
+const sandbox = sinon.createSandbox();
+
+describe("options", () => {
+  let stub;
+  before(() => {
+    stub = sandbox.stub(monitoring);
+  });
+  after(() => {
+    sandbox.restore();
+  });
+  describe("without createTimeSeriesTimeoutSeconds", () => {
+    it("is not passed to MetricServiceClient", () => {
+      let ctorOpts;
+      class FakeMetricServiceClient {
+        constructor(opts) {
+          ctorOpts = opts;
+        }
+      }
+      stub.MetricServiceClient = (FakeMetricServiceClient);
+      pushClient({
+        projectId: "myproject",
+        resourceProvider: globalResourceProvider,
+      });
+      expect(ctorOpts).to.eql({});
+    });
+  });
+  describe("with createTimeSeriesTimeoutSeconds", () => {
+    it("is passed to MetricServiceClient", () => {
+      let ctorOpts;
+      class FakeMetricServiceClient {
+        constructor(opts) {
+          ctorOpts = opts;
+        }
+      }
+      stub.MetricServiceClient = (FakeMetricServiceClient);
+      pushClient({
+        projectId: "myproject",
+        resourceProvider: globalResourceProvider,
+        createTimeSeriesTimeoutSeconds: 60,
+      });
+      expect(ctorOpts).to.eql(
+        {
+          clientConfig: {
+            interfaces: {
+              "google.monitoring.v3.MetricService": {
+                methods: {
+                  CreateTimeSeries: {
+                    timeout_millis: 60000,
+                  },
+                },
+              },
+            },
+          },
+        }
+      );
+    });
+  });
+});


### PR DESCRIPTION
We see a lot of these errors, especially on start up, from `gcp-push-metrics` when used in a Cloud Run app.

```
pushClient: Unable to push metrics: Error: 4 DEADLINE_EXCEEDED: Deadline exceeded. Stack: Error: 4 DEADLINE_EXCEEDED: Deadline exceeded
    at Object.callErrorFromStatus (/opt/app/node_modules/@grpc/grpc-js/build/src/call.js:31:26)
    at Object.onReceiveStatus (/opt/app/node_modules/@grpc/grpc-js/build/src/client.js:180:52)
    at Object.onReceiveStatus (/opt/app/node_modules/@grpc/grpc-js/build/src/client-interceptors.js:365:141)
    at Object.onReceiveStatus (/opt/app/node_modules/@grpc/grpc-js/build/src/client-interceptors.js:328:181)
    at /opt/app/node_modules/@grpc/grpc-js/build/src/call-stream.js:187:78
    at processTicksAndRejections (node:internal/process/task_queues:78:11)
```

As stated under `options.clientConfig` [here](https://github.com/googleapis/gax-nodejs/blob/main/client-libraries.md#constructor-options) it is possible to override the client configuration when creating a new instance of `MetricServiceClient`. The default configuration can be found [here](https://github.com/googleapis/nodejs-monitoring/blob/main/src/v3/metric_service_client_config.json).

This PR makes it possible to override the `interfaces["google.monitoring.v3.MetricService"].methods.CreateTimeSeries. timeout_millis` property which defaults to 12000 millis (12 seconds).

After some testing bumping this to 40000 millis (40 seconds) seems to resolve the DEADLINE_EXCEEDED issue on startup. This will be set as default if no value is passed when creating a client.