### PR TITLE
Expose grpc keepalive options to prevent DEADLINE_EXCEEDED errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.2.0
+
+- Expose grpc options `keepalive_timeout_ms` and `keepalive_time_ms` to counter DEADLINE_EXCEEDED errors thrown by google when pushing metrics.
+
 ## 3.1.1
 
 - Bump deps

--- a/index.cjs
+++ b/index.cjs
@@ -418,7 +418,7 @@ function pushClient({ intervalSeconds, logger, resourceProvider, grpcKeepaliveTi
     opts["grpc.keepalive_time_ms"] = grpcKeepaliveTimeMs;
   }
 
-  const metricsClient = new monitoring.MetricServiceClient();
+  const metricsClient = new monitoring.MetricServiceClient(opts);
   const metrics = [];
   let intervalEnd;
 

--- a/index.cjs
+++ b/index.cjs
@@ -386,7 +386,7 @@ function request(path) {
   });
 }
 
-function pushClient({ intervalSeconds, logger, resourceProvider } = {}) {
+function pushClient({ intervalSeconds, logger, resourceProvider, grpcKeepaliveTimeoutMs, grpcKeepaliveTimeMs } = {}) {
   if (intervalSeconds < 1) {
     throw new Error("intervalSeconds must be at least 1");
   }
@@ -406,6 +406,16 @@ function pushClient({ intervalSeconds, logger, resourceProvider } = {}) {
 
   if (!logger.debug || !logger.error) {
     throw new Error("logger must have methods 'debug' and 'error'");
+  }
+
+  const opts = {};
+
+  if (grpcKeepaliveTimeoutMs) {
+    opts["grpc.keepalive_timeout_ms"] = grpcKeepaliveTimeoutMs;
+  }
+
+  if (grpcKeepaliveTimeMs) {
+    opts["grpc.keepalive_time_ms"] = grpcKeepaliveTimeMs;
   }
 
   const metricsClient = new monitoring.MetricServiceClient();

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ import gauge from "./lib/gauge.js";
 import summary from "./lib/summary.js";
 import cloudRunResourceProvider from "./lib/cloudRunResourceProvider.js";
 
-function pushClient({ intervalSeconds, createTimeSeriesTimeoutSeconds = 40, logger, resourceProvider } = {}) {
+function pushClient({ intervalSeconds, createTimeSeriesTimeoutSeconds = 40, logger, resourceProvider, grpcKeepaliveTimeoutMs, grpcKeepaliveTimeMs } = {}) {
   if (intervalSeconds < 1) {
     throw new Error("intervalSeconds must be at least 1");
   }
@@ -30,6 +30,14 @@ function pushClient({ intervalSeconds, createTimeSeriesTimeoutSeconds = 40, logg
   const opts = {};
   if (createTimeSeriesTimeoutSeconds) {
     opts.clientConfig = { interfaces: { "google.monitoring.v3.MetricService": { methods: { CreateTimeSeries: { timeout_millis: createTimeSeriesTimeoutSeconds * 1000 } } } } };
+  }
+
+  if (grpcKeepaliveTimeoutMs) {
+    opts["grpc.keepalive_timeout_ms"] = grpcKeepaliveTimeoutMs;
+  }
+
+  if (grpcKeepaliveTimeMs) {
+    opts["grpc.keepalive_time_ms"] = grpcKeepaliveTimeMs;
   }
 
   const metricsClient = new monitoring.MetricServiceClient(opts);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bonniernews/gcp-push-metrics",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bonniernews/gcp-push-metrics",
-      "version": "3.1.1",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/monitoring": "^3.0.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/gcp-push-metrics",
-  "version": "3.1.1",
+  "version": "3.2.0",
   "description": "Push custom metrics to Google Cloud Monitoring.",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
An attempt to get rid of errors related to the deadline being exceeded when pushing metrics.

If it seems to work an option could be to add default values to the parameters. 

Related solutions:
- https://github.com/googleapis/nodejs-pubsub/issues/1779
- https://github.com/googleapis/nodejs-pubsub/issues/1515#issuecomment-1665969983