### PR TITLE
Add flag disabling pushes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 4.1.0
+- Added parameter `disabled` for disabling pushing metrics locally
+
 ## 4.0.0
 
 - Bumped deps

--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ We then proceed to create a counter named "num_requests" and increment it. Once 
 
 > Note: Every time `pushClient` is invoked it will create a new instance which in turn will set up a setTimeout loop that will push metrics collected by the client. In most cases you should only create a single client within your application and expose it as a singleton.
 
+### Disabling locally
+
+When running applications locally, for instance in a development environment, you may want to disable pushing metrics to the Cloud Monitoring API. This can be done by passing `disabled: true` to the client:
+
+```js
+const client = pushClient({
+  resourceProvider: cloudRunResourceProvider,
+  disabled: process.env.NODE_ENV === "development"
+});
+```
+
 ## Counters
 
 Counters are implemented as the CUMULATIVE metric kind and the value reported will continously increase. Let's look at an example:

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ import gauge from "./lib/gauge.js";
 import summary from "./lib/summary.js";
 import cloudRunResourceProvider from "./lib/cloudRunResourceProvider.js";
 
-function pushClient({ intervalSeconds, createTimeSeriesTimeoutSeconds = 40, logger, resourceProvider, grpcKeepaliveTimeoutMs, grpcKeepaliveTimeMs } = {}) {
+function pushClient({ intervalSeconds, createTimeSeriesTimeoutSeconds = 40, logger, resourceProvider, grpcKeepaliveTimeoutMs, grpcKeepaliveTimeMs, disabled } = {}) {
   if (intervalSeconds < 1) {
     throw new Error("intervalSeconds must be at least 1");
   }
@@ -102,9 +102,12 @@ function pushClient({ intervalSeconds, createTimeSeriesTimeoutSeconds = 40, logg
     }
     setTimeout(push, intervalSeconds * 1000);
   }
-  setTimeout(push, intervalSeconds * 1000);
 
-  process.on("SIGTERM", push.bind(null, true));
+  if (!disabled) {
+    setTimeout(push, intervalSeconds * 1000);
+
+    process.on("SIGTERM", push.bind(null, true));
+  }
 
   return { counter: createCounter, gauge: createGauge, summary: createSummary };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bonniernews/gcp-push-metrics",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bonniernews/gcp-push-metrics",
-      "version": "4.0.0",
+      "version": "4.1.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/monitoring": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bonniernews/gcp-push-metrics",
-  "version": "4.0.0",
+  "version": "4.1.0",
   "description": "Push custom metrics to Google Cloud Monitoring.",
   "main": "index.js",
   "type": "module",


### PR DESCRIPTION
When running locally (when with several services), the logs quickly fill up with push errors, since the server is not available. This PR introduces an optional flag that disables pushes.